### PR TITLE
Update the version label in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN echo "Red Hat Ceph Storage Server 9 (Container)" > /etc/redhat-storage-relea
 EXPOSE 6789 6800 6801 6802 6803 6804 6805 80 5000
 
 # Atomic specific labels
-LABEL version="9"
+LABEL version="10"
 
 # Build specific labels
 LABEL com.redhat.component="rhceph-container"


### PR DESCRIPTION
Hi @andrewschoen ,

 ```
         },
          "Labels": {
               "CEPH_POINT_RELEASE": "",
               "GIT_BRANCH": "main",
               "GIT_CLEAN": "True",
               "GIT_COMMIT": "55ad0f204a1d654ee565abf874aecad0cc209d0e",
               "GIT_REPO": "https://github.com/ibmstorage/rhceph-container.git",
               "RELEASE": "release-9.0",
               "architecture": "x86_64",
               "build-date": "2025-10-27T20:14:58Z",
               "ceph": "True",
               "com.redhat.component": "rhceph-container",
               "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
               "cpe": "cpe:/a:redhat:ceph_storage:9::el10",
               "description": "Red Hat Ceph Storage 9",
               "distribution-scope": "public",
               "io.buildah.version": "1.41.4",
               "io.k8s.description": "Red Hat Ceph Storage 9",
               "io.k8s.display-name": "Red Hat Ceph Storage 9 on RHEL 9",
               "io.openshift.expose-services": "",
               "io.openshift.tags": "rhceph ceph",
               "maintainer": "Guillaume Abrioux <gabrioux@redhat.com>",
               "name": "rhceph",
               "org.opencontainers.image.created": "",
               "org.opencontainers.image.revision": "124f34e6671107088445cd658bdc85c9c5718f40",
               "quay.expires-after": "5d",
               "release": "1758699349",
               "summary": "Provides the latest Red Hat Ceph Storage 9 on RHEL 9 in a fully featured and supported base image.",
               "url": "https://catalog.redhat.com/en/search?searchType=containers",
               "vcs-ref": "124f34e6671107088445cd658bdc85c9c5718f40",
               "vcs-type": "git",
               "vendor": "Red Hat, Inc.",
               "version": "9"
          },
```

The version tag is coming below the vendor and it kinda confusing people whether the base image is `ubi9` or `ubi8`. 

Please feel free to merge or close this merge if you feel like the change is valid.
