### PR TITLE
Increase timeout

### DIFF
--- a/.tekton/rhceph-container-9-0-pull-request.yaml
+++ b/.tekton/rhceph-container-9-0-pull-request.yaml
@@ -17,6 +17,9 @@ metadata:
   name: rhceph-container-9-0-on-pull-request
   namespace: ceph-tenant
 spec:
+  timeouts:
+    pipeline: 4h
+    tasks: 3h
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/rhceph-container-9-0-push.yaml
+++ b/.tekton/rhceph-container-9-0-push.yaml
@@ -16,6 +16,9 @@ metadata:
   name: rhceph-container-9-0-on-push
   namespace: ceph-tenant
 spec:
+  timeouts:
+    pipeline: 4h
+    tasks: 3h
   params:
   - name: git-url
     value: '{{source_url}}'


### PR DESCRIPTION
Increase the timeout 4hrs for the pull & push pipeline runs, as s390x and ppc64le builds taking longer the default 2hrs
    
Ref: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/ceph-tenant/applications/ceph-9-0/pipelineruns/rhceph-container-9-0-on-push-c4vf6
