### PR TITLE
Add the label Z-VERSION to indicate the z-stream label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ LABEL CEPH_POINT_RELEASE=""
 # The CPE (Common Platform Enumeration) identifier for Ceph.
 LABEL cpe=cpe:/a:redhat:ceph_storage:7.1::el9
 
+# Z-stream indicator
+LABEL Z-VERSION="7.1z10"
+
 ENV CEPH_VERSION reef
 ENV CEPH_POINT_RELEASE ""
 ENV CEPH_DEVEL false


### PR DESCRIPTION
This label can come handy to us in 3 places:

While sending konflux emails, all we have to do is read this label
We are now adding z-stream label when releasing the container in konflux RPA so we were able to test that we can propagate the value properly, thus preventing any manual effort needed
This also comes handy for the end-to-end automation of respin work that I am doing.